### PR TITLE
Change search install to explicit install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git submodule update --init --recursive
 
 Add the `nixenv` directive to your `install.yaml`. 
 
-Using string values is equivalent to `nix-env -i <package>`, which will install the latest version available. 
+Using string values is equivalent to `nix-env -iA <package>`, which will install the latest version available. 
 Using a hash `{ <package>: <revision> }` is equivalent `nix-env -iA <package> -f <revision>`.
 
 You can find package revisions here: [https://lazamar.co.uk/nix-versions/](https://lazamar.co.uk/nix-versions/)
@@ -24,8 +24,8 @@ You can find package revisions here: [https://lazamar.co.uk/nix-versions/](https
 - nixenv:
     packages:
       - nodejs-15_x: 'https://github.com/NixOS/nixpkgs/archive/5c79b3dda06744a55869cae2cba6873fbbd64394.tar.gz'
-      - htop
-      - multitail
+      - nixpkgs.htop
+      - nixpkgs.multitail
 ```
 
 ## Dev Setup

--- a/lib/nixenv.py
+++ b/lib/nixenv.py
@@ -37,9 +37,9 @@ class NixEnv:
         raise NixEnv.NixEnvException(self.__decode(r.stderr))
 
     def install(self, package: str, rev_path: str = None) -> str:
-        cmd = f'--install {package}'
+        cmd = f'--install --attr {package}'
         if rev_path is not None:
-            cmd = f'{cmd} --attr -f {rev_path}'
+            cmd = f'{cmd} -f {rev_path}'
 
         try:
             return self.nix_env(cmd)

--- a/tests/nixenv_test.py
+++ b/tests/nixenv_test.py
@@ -32,7 +32,7 @@ class TestNixEnv(unittest.TestCase):
             r = nix.install('multitail')
             self.assertEqual(r, "installing 'multitail-7.0.0'")
             args, _ = mock.call_args
-            self.assertEqual(args[0], 'nix-env --install multitail')
+            self.assertEqual(args[0], 'nix-env --install --attr multitail')
 
     def test_install_fails(self):
         mock = MagicMock(return_value=CompletedProcess(


### PR DESCRIPTION
Fixes: https://github.com/DanTheMinotaur/dotbot-nix-env/issues/1

Makes install explicit instead of searching through nix packages before install. 